### PR TITLE
throw InvalidArgumentException if ttl is negative

### DIFF
--- a/src/Lock.php
+++ b/src/Lock.php
@@ -173,9 +173,8 @@ final class Lock implements LockInterface
     {
         if ($ttl instanceof DateInterval) {
             return (int) \round((int)$ttl->format('%s') * 1_000_000);
-        }
-        if ($ttl < 0) {
-            throw new \InvalidArgumentException('TTL must be positive');
+
+\assert($ttl >= 0, 'TTL must be positive');
         }
 
         return (int) \round($ttl * 1_000_000);

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace RoadRunner\Lock;
 
 use DateInterval;
+use http\Exception\InvalidArgumentException;
 use RoadRunner\Lock\DTO\V1BETA1\{
     Request, Response
 };
@@ -33,6 +34,8 @@ final class Lock implements LockInterface
      * @param int|float|DateInterval $ttl The time-to-live of the lock, in seconds. Defaults to 0 (forever).
      * @param int|float|DateInterval $waitTTL How long to wait to acquire lock until returning false.
      * @return false|non-empty-string Returns lock ID if the lock was acquired successfully, false otherwise.
+     *
+     * @throws \InvalidArgumentException If ttl is negative.
      */
     public function lock(
         string $resource,
@@ -63,6 +66,8 @@ final class Lock implements LockInterface
      * @param int|float|DateInterval $ttl The time-to-live of the lock, in seconds. Defaults to 0 (forever).
      * @param int|float|DateInterval $waitTTL How long to wait to acquire lock until returning false.
      * @return false|non-empty-string Returns lock ID if the lock was acquired successfully, false otherwise.
+     *
+     * @throws \InvalidArgumentException If ttl is negative.
      */
     public function lockRead(
         string $resource,
@@ -150,6 +155,8 @@ final class Lock implements LockInterface
      * @param string $id An identifier for the process that is releasing the lock.
      * @param int|float|DateInterval $ttl The new TTL in seconds.
      * @return bool Returns true on success and false on failure.
+     *
+     * @throws \InvalidArgumentException If ttl is negative.
      */
     public function updateTTL(string $resource, string $id, int|float|DateInterval $ttl): bool
     {

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace RoadRunner\Lock;
 
 use DateInterval;
-use http\Exception\InvalidArgumentException;
 use RoadRunner\Lock\DTO\V1BETA1\{
     Request, Response
 };

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -173,9 +173,9 @@ final class Lock implements LockInterface
     {
         if ($ttl instanceof DateInterval) {
             return (int) \round((int)$ttl->format('%s') * 1_000_000);
-
-\assert($ttl >= 0, 'TTL must be positive');
         }
+
+            \assert($ttl >= 0, 'TTL must be positive');
 
         return (int) \round($ttl * 1_000_000);
     }

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -175,7 +175,7 @@ final class Lock implements LockInterface
             return (int) \round((int)$ttl->format('%s') * 1_000_000);
         }
 
-            \assert($ttl >= 0, 'TTL must be positive');
+     \assert($ttl >= 0, 'TTL must be positive');
 
         return (int) \round($ttl * 1_000_000);
     }

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -175,7 +175,7 @@ final class Lock implements LockInterface
             return (int) \round((int)$ttl->format('%s') * 1_000_000);
         }
 
-     \assert($ttl >= 0, 'TTL must be positive');
+        \assert($ttl >= 0, 'TTL must be positive');
 
         return (int) \round($ttl * 1_000_000);
     }

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -166,10 +166,13 @@ final class Lock implements LockInterface
     private function convertTimeToMicroseconds(int|float|DateInterval $ttl): int
     {
         if ($ttl instanceof DateInterval) {
-            return (int) round((int)$ttl->format('%s') * 1_000_000);
+            return (int) \round((int)$ttl->format('%s') * 1_000_000);
+        }
+        if ($ttl < 0) {
+            throw new \InvalidArgumentException('TTL must be positive');
         }
 
-        return (int) round($ttl * 1_000_000);
+        return (int) \round($ttl * 1_000_000);
     }
 
     /**

--- a/tests/src/LockTest.php
+++ b/tests/src/LockTest.php
@@ -62,8 +62,8 @@ final class LockTest extends TestCase
                     && $request->getResource() === 'resource'
                     && $request->getId() === ($id === null ? 'some-id' : $id)
                     && $request->getTtl() === $expectedTtlMicroseconds
-                && $request->getWait() === $expectedWaitSec
-                && $response === Response::class;
+                    && $request->getWait() === $expectedWaitSec
+                    && $response === Response::class;
             })
             ->andReturn(new Response(['ok' => $expectedResult]));
 
@@ -218,5 +218,35 @@ final class LockTest extends TestCase
     {
         yield [true];
         yield [false];
+    }
+
+    public function testLockNegativeTtl(): void
+    {
+        self::expectException(\LogicException::class);
+        $this->lock->lock('resource', 'uuid', -300);
+    }
+
+    public function testLockNegativeWaitTtl(): void
+    {
+        self::expectException(\LogicException::class);
+        $this->lock->lock('resource', 'uuid', 0, -300);
+    }
+
+    public function testLockReadNegativeTtl(): void
+    {
+        self::expectException(\LogicException::class);
+        $this->lock->lock('resource', 'uuid', -300);
+    }
+
+    public function testLockReadNegativeWaitTtl(): void
+    {
+        self::expectException(\LogicException::class);
+        $this->lock->lockRead('resource', 'uuid', 0, -300);
+    }
+
+    public function testUpdateNegativeWaitTtl(): void
+    {
+        self::expectException(\LogicException::class);
+        $this->lock->updateTTL('resource', 'uuid', -300);
     }
 }


### PR DESCRIPTION
Some paranoid commit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced exception handling for negative Time-To-Live (TTL) values in lock-related functions.
- **Tests**
	- Added new tests to ensure proper exception handling for negative TTL and wait TTL values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->